### PR TITLE
Improve redirection target parsing

### DIFF
--- a/src/Helpmebot/ExtensionMethods/ArrayExtensions.cs
+++ b/src/Helpmebot/ExtensionMethods/ArrayExtensions.cs
@@ -20,6 +20,7 @@
 
 namespace Helpmebot.ExtensionMethods
 {
+    using System;
     using System.Linq;
 
     /// <summary>
@@ -56,6 +57,31 @@ namespace Helpmebot.ExtensionMethods
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Get an sub-array of the array
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type parameter
+        /// </typeparam>
+        /// <param name="data">
+        /// The array.
+        /// </param>
+        /// <param name="index">
+        /// The index of the starting element of the sub-array.
+        /// </param>
+        /// <param name="length">
+        /// The length of the sub-array.
+        /// </param>
+        /// <returns>
+        /// The resulting sub-array.
+        /// </returns>
+        public static T[] SubArray<T>(this T[] data, int index, int length)
+        {
+            T[] result = new T[length];
+            Array.Copy(data, index, result, 0, length);
+            return result;
         }
 
         /// <summary>

--- a/src/Helpmebot/Legacy/LegacyCommandParser.cs
+++ b/src/Helpmebot/Legacy/LegacyCommandParser.cs
@@ -305,26 +305,37 @@ namespace Helpmebot.Legacy
         private static string FindRedirection(ref string[] args)
         {
             string directedTo = string.Empty;
-
-            foreach (string arg in args.Where(x => x.StartsWith(">")))
+            int a = 0;
+            foreach (string arg in args)
             {
-                directedTo = arg.Substring(1);
-
-                var count = args.Count(i => i == arg);
-
-                var newArray = new string[args.Length - count];
-
-                var nextAddition = 0;
-
-                foreach (var i in args.Where(i => i != arg))
+                if (arg == ">")
                 {
-                    newArray[nextAddition] = i;
-                    nextAddition++;
+                    // The target comes in the next argument(s)
+                    var target = args.SubArray(a + 1, args.Length - a - 1);
+                    args = args.SubArray(0, a);
+                    directedTo = String.Join(" ", target);
                 }
+                else if (arg.StartsWith(">"))
+                {
+                    // The target nick is in the argument
+                    directedTo = arg.Substring(1);
 
-                args = newArray;
+                    var count = args.Count(i => i == arg);
+
+                    var newArray = new string[args.Length - count];
+
+                    var nextAddition = 0;
+
+                    foreach (var i in args.Where(i => i != arg))
+                    {
+                        newArray[nextAddition] = i;
+                        nextAddition++;
+                    }
+
+                    args = newArray;
+                }
+                a++;
             }
-
             return directedTo;
         }
 
@@ -419,3 +430,4 @@ namespace Helpmebot.Legacy
         #endregion
     }
 }
+


### PR DESCRIPTION
This commit improves FindRedirection() by allowing a space
after >, which makes nickname completion possible.

Signed-off-by: Zhaofeng Li <hello@zhaofeng.li>