### PR TITLE
AH ha..

### DIFF
--- a/src/Helpmebot/Legacy/Commands/UserInfo.cs
+++ b/src/Helpmebot/Legacy/Commands/UserInfo.cs
@@ -267,7 +267,7 @@ namespace helpmebot6.Commands
         /// <param name="userInformation">The user information.</param>
         private void SendShortUserInfo(UserInformation userInformation)
         {
-            const string Regex = "^http://en.wikipedia.org/wiki/";
+            const string Regex = "^https://en.wikipedia.org/wiki/";
             const string ShortUrlAlias = "http://enwp.org/";
             var r = new Regex(Regex);
 


### PR DESCRIPTION
The regex wasn't looking for the right URL to replace and use the short form...