### PR TITLE
Add command to refresh the ResponseRepository

### DIFF
--- a/src/Helpmebot/Helpmebot.csproj
+++ b/src/Helpmebot/Helpmebot.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Legacy\Commands\FunStuff\TargetedFunCommand.cs" />
     <Compile Include="Legacy\Commands\FunStuff\Whistle.cs" />
     <Compile Include="Legacy\Commands\Google.cs" />
+    <Compile Include="Legacy\Commands\Refresh.cs" />
     <Compile Include="Legacy\Commands\Reg.cs" />
     <Compile Include="Configuration\ConfigurationHelper.cs" />
     <Compile Include="Configuration\XmlSections\PrivateConfiguration.cs" />

--- a/src/Helpmebot/Legacy/Commands/Refresh.cs
+++ b/src/Helpmebot/Legacy/Commands/Refresh.cs
@@ -58,9 +58,9 @@ namespace helpmebot6.Commands
         protected override CommandResponseHandler ExecuteCommand()
         {
             this.CommandServiceHelper.MessageService.RefreshResponseRepository();
-            this.CommandServiceHelper.Client.SendMessage(this.Source.Nickname, "Done.");
 
-            return new CommandResponseHandler();
+            return new CommandResponseHandler(this.CommandServiceHelper.MessageService.Done(this.Channel),
+                CommandResponseDestination.PrivateMessage);
         }
 
         #endregion

--- a/src/Helpmebot/Legacy/Commands/Refresh.cs
+++ b/src/Helpmebot/Legacy/Commands/Refresh.cs
@@ -1,0 +1,68 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Refresh.cs" company="Helpmebot Development Team">
+//   Helpmebot is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   Helpmebot is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with Helpmebot.  If not, see http://www.gnu.org/licenses/ .
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+namespace helpmebot6.Commands
+{
+    using Helpmebot;
+    using Helpmebot.Commands.Interfaces;
+    using Helpmebot.Legacy.Model;
+
+    /// <summary>
+    /// Refreshes the bot's <see cref="Helpmebot.Repositories.ResponseRepository"/>, forcing a reload from the database
+    /// </summary>
+    internal class Refresh : GenericCommand
+    {
+        #region Constructors and Destructors
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="Refresh"/> class.
+        /// </summary>
+        /// <param name="source">
+        /// The source.
+        /// </param>
+        /// <param name="channel">
+        /// The channel.
+        /// </param>
+        /// <param name="args">
+        /// The args.
+        /// </param>
+        /// <param name="commandServiceHelper">
+        /// The message Service.
+        /// </param>
+        public Refresh(LegacyUser source, string channel, string[] args, ICommandServiceHelper commandServiceHelper)
+            : base(source, channel, args, commandServiceHelper)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        ///     Actual command logic
+        /// </summary>
+        /// <returns>the response</returns>
+        protected override CommandResponseHandler ExecuteCommand()
+        {
+            this.CommandServiceHelper.MessageService.RefreshResponseRepository();
+            this.CommandServiceHelper.Client.SendMessage(this.Source.Nickname, "Done.");
+
+            return new CommandResponseHandler();
+        }
+
+        #endregion
+    }
+}

--- a/src/Helpmebot/Repositories/Interfaces/IRepository.cs
+++ b/src/Helpmebot/Repositories/Interfaces/IRepository.cs
@@ -107,6 +107,22 @@ namespace Helpmebot.Repositories.Interfaces
         T GetById(int id);
 
         /// <summary>
+        /// Refresh the model from the database, bypassing the NHibernate level-one cache.
+        /// </summary>
+        /// <param name="model">
+        /// The model to be refreshed
+        /// </param>
+        void Refresh(T model);
+
+        /// <summary>
+        /// Refreshes an IEnumerable of models from the database, bypassing the NHibernate level-one cache.
+        /// </summary>
+        /// <param name="models">
+        /// The models to be refreshed
+        /// </param>
+        void Refresh(IEnumerable<T> models);
+
+        /// <summary>
         /// Executes a callback in the context of a transaction.
         /// </summary>
         /// <param name="callback">

--- a/src/Helpmebot/Repositories/Interfaces/IResponseRepository.cs
+++ b/src/Helpmebot/Repositories/Interfaces/IResponseRepository.cs
@@ -34,5 +34,11 @@ namespace Helpmebot.Repositories.Interfaces
         /// The <see cref="Response"/>.
         /// </returns>
         Response GetByName(string messageKey);
+
+        /// <summary>
+        /// This rather expensive operation forces NHibernate to re-read all <see cref="Response">Responses</see> from
+        /// the database.
+        /// </summary>
+        void RefreshAllResponses();
     }
 }

--- a/src/Helpmebot/Repositories/RepositoryBase.cs
+++ b/src/Helpmebot/Repositories/RepositoryBase.cs
@@ -327,6 +327,51 @@ namespace Helpmebot.Repositories
             this.session.SaveOrUpdate(model);
         }
 
+
+        /// <summary>
+        /// Refresh the model from the database, bypassing the NHibernate level-one cache.
+        /// </summary>
+        /// <param name="model">
+        /// The model to be refreshed
+        /// </param>
+        public void Refresh(T model)
+        {
+            lock (this.sessionLock)
+            {
+                this.DoRefresh(model);
+            }
+        }
+
+        /// <summary>
+        /// Refreshes an IEnumerable of models from the database, bypassing the NHibernate level-one cache.
+        /// </summary>
+        /// <param name="models">
+        /// The models to be refreshed
+        /// </param>
+        public void Refresh(IEnumerable<T> models)
+        {
+            lock (this.sessionLock)
+            {
+                foreach (var model in models)
+                {
+                    this.DoRefresh(model);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Perform the actual refresh operation, refreshing the given model from the database while bypassing the
+        /// NHibernate level-one cache.
+        /// </summary>
+        /// <param name="model">
+        /// The model to be refreshed
+        /// </param>
+        private void DoRefresh(T model)
+        {
+            this.Logger.DebugFormat("Refreshing model {0} ({1})...", model, model.GetType().Name);
+            this.session.Refresh(model);
+        }
+
         #endregion
     }
 }

--- a/src/Helpmebot/Repositories/ResponseRepository.cs
+++ b/src/Helpmebot/Repositories/ResponseRepository.cs
@@ -66,6 +66,15 @@ namespace Helpmebot.Repositories
             return this.Get(Restrictions.Eq("Name", Encoding.UTF8.GetBytes(messageKey))).FirstOrDefault();
         }
 
+        /// <summary>
+        /// This rather expensive operation forces NHibernate to re-read all <see cref="Response">Responses</see> from
+        /// the database.
+        /// </summary>
+        public void RefreshAllResponses()
+        {
+            this.Refresh(this.Get());
+        }
+
         #endregion
 
         #region Methods

--- a/src/Helpmebot/Services/Interfaces/IMessageService.cs
+++ b/src/Helpmebot/Services/Interfaces/IMessageService.cs
@@ -74,5 +74,11 @@ namespace Helpmebot.Services.Interfaces
         /// The <see cref="string"/>.
         /// </returns>
         string Done(object context);
+
+        /// <summary>
+        /// Refreshes the <see cref="Helpmebot.Repositories.ResponseRepository">ResponseRepository</see> from the
+        /// database.
+        /// </summary>
+        void RefreshResponseRepository();
     }
 }

--- a/src/Helpmebot/Services/MessageService.cs
+++ b/src/Helpmebot/Services/MessageService.cs
@@ -166,6 +166,16 @@ namespace Helpmebot.Services
             return this.RetrieveMessage(messageKey, string.Empty, arguments);
         }
 
+
+        /// <summary>
+        /// Refreshes the <see cref="Helpmebot.Repositories.ResponseRepository">ResponseRepository</see> from the
+        /// database.
+        /// </summary>
+        public void RefreshResponseRepository()
+        {
+            this.responseRepository.RefreshAllResponses();
+        }
+
         #endregion
 
         #region Methods


### PR DESCRIPTION
Adds a !refresh command that has the effect of refreshing the ResponseRepository from the database, bypassing NHibernate's level-one cache.  All changes in the database to saved messages will immediately take effect after this command is given.

(first pull request, pls be gentle)